### PR TITLE
RandomHoi fails on Clean TFH 4.02 installation because certain directories aren't created during the randomisation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,3 @@ Solution for Visual Studio 2012, framework 2.0.
 
 
 Not all files required to run the generator correctly are included. You need to downlad randomHoiV2 from paradox forums to get all files.
-
-http://forum.paradoxplaza.com/forum/showthread.php?473568-DOWNLOAD-Random-Scenario-for-normal-Map-2.7-TFH-2.43-FTM-1.72-SF-and-1.3-HOI
-
-You need to register your Hoi III copy on paradox forum to gain access to your download

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Solution for Visual Studio 2012, framework 2.0.
 
 
 Not all files required to run the generator correctly are included. You need to downlad randomHoiV2 from paradox forums to get all files.
+
+http://forum.paradoxplaza.com/forum/showthread.php?473568-DOWNLOAD-Random-Scenario-for-normal-Map-2.7-TFH-2.43-FTM-1.72-SF-and-1.3-HOI
+
+You need to register your Hoi III copy on paradox forum to gain access to your download

--- a/RandomHoiV2/Form1.cs
+++ b/RandomHoiV2/Form1.cs
@@ -1861,6 +1861,8 @@ namespace RandomHoiV2
                 {
 
                     //create directories
+                    System.IO.Directory.CreateDirectory(Application.StartupPath + "/cgm");
+                    System.IO.Directory.CreateDirectory(Application.StartupPath + "/common");
                     System.IO.Directory.CreateDirectory(Application.StartupPath + "/common/countries");
                     System.IO.Directory.CreateDirectory(Application.StartupPath + "/history");
                     System.IO.Directory.CreateDirectory(Application.StartupPath + "/history/countries");
@@ -1870,6 +1872,9 @@ namespace RandomHoiV2
                     System.IO.Directory.CreateDirectory(Application.StartupPath + "/history/leaders");
                     System.IO.Directory.CreateDirectory(Application.StartupPath + "/history/wars");
                     System.IO.Directory.CreateDirectory(Application.StartupPath + "/history/diplomacy");
+                    System.IO.Directory.CreateDirectory(Application.StartupPath + "/localisation");
+                    System.IO.Directory.CreateDirectory(Application.StartupPath + "/script");
+                    System.IO.Directory.CreateDirectory(Application.StartupPath + "/script/country");
                 }
 
                 catch (Exception ex)


### PR DESCRIPTION
This change simply adds in a few missing directories to the existing list of those that should be created up front
